### PR TITLE
[Feature] Implement repository detail screen

### DIFF
--- a/GitHubRepository.xcodeproj/project.pbxproj
+++ b/GitHubRepository.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		9392A8292C60318B0015DD01 /* RepositoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A8282C60318B0015DD01 /* RepositoryDetailView.swift */; };
 		9392A82C2C6032650015DD01 /* RepositoryDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A82B2C6032650015DD01 /* RepositoryDetailViewModel.swift */; };
 		9392A82E2C6037920015DD01 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A82D2C6037920015DD01 /* String+Extension.swift */; };
+		9392A8322C6040920015DD01 /* RepositoryDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A8312C6040910015DD01 /* RepositoryDetailViewModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +64,7 @@
 		9392A8282C60318B0015DD01 /* RepositoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailView.swift; sourceTree = "<group>"; };
 		9392A82B2C6032650015DD01 /* RepositoryDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewModel.swift; sourceTree = "<group>"; };
 		9392A82D2C6037920015DD01 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
+		9392A8312C6040910015DD01 /* RepositoryDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -250,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				9392A81E2C5EE0810015DD01 /* ReposViewModelTests.swift */,
+				9392A8312C6040910015DD01 /* RepositoryDetailViewModelTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -411,6 +414,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9392A81F2C5EE0810015DD01 /* ReposViewModelTests.swift in Sources */,
+				9392A8322C6040920015DD01 /* RepositoryDetailViewModelTests.swift in Sources */,
 				9392A7FF2C5E0F000015DD01 /* GitHubServiceTests.swift in Sources */,
 				9392A8042C5E0FCA0015DD01 /* URLProtocolMock.swift in Sources */,
 			);

--- a/GitHubRepository.xcodeproj/project.pbxproj
+++ b/GitHubRepository.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		9392A81D2C5ED9F30015DD01 /* RepositoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A81C2C5ED9F30015DD01 /* RepositoryCollectionViewCell.swift */; };
 		9392A81F2C5EE0810015DD01 /* ReposViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A81E2C5EE0810015DD01 /* ReposViewModelTests.swift */; };
 		9392A8222C5F0A480015DD01 /* RepositorySectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A8212C5F0A480015DD01 /* RepositorySectionHeaderView.swift */; };
+		9392A8262C6031690015DD01 /* RepositoryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A8252C6031690015DD01 /* RepositoryDetailViewController.swift */; };
+		9392A8292C60318B0015DD01 /* RepositoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A8282C60318B0015DD01 /* RepositoryDetailView.swift */; };
+		9392A82C2C6032650015DD01 /* RepositoryDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A82B2C6032650015DD01 /* RepositoryDetailViewModel.swift */; };
+		9392A82E2C6037920015DD01 /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9392A82D2C6037920015DD01 /* String+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +59,10 @@
 		9392A81C2C5ED9F30015DD01 /* RepositoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		9392A81E2C5EE0810015DD01 /* ReposViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReposViewModelTests.swift; sourceTree = "<group>"; };
 		9392A8212C5F0A480015DD01 /* RepositorySectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositorySectionHeaderView.swift; sourceTree = "<group>"; };
+		9392A8252C6031690015DD01 /* RepositoryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewController.swift; sourceTree = "<group>"; };
+		9392A8282C60318B0015DD01 /* RepositoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailView.swift; sourceTree = "<group>"; };
+		9392A82B2C6032650015DD01 /* RepositoryDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailViewModel.swift; sourceTree = "<group>"; };
+		9392A82D2C6037920015DD01 /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +171,7 @@
 		9392A7EF2C5DF0B30015DD01 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				9392A8232C6031490015DD01 /* Repository Details */,
 				9392A7EA2C5DF02A0015DD01 /* Repositories */,
 			);
 			path = Screens;
@@ -197,6 +206,7 @@
 		9392A7F32C5DF1020015DD01 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
+				9392A82D2C6037920015DD01 /* String+Extension.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -242,6 +252,40 @@
 				9392A81E2C5EE0810015DD01 /* ReposViewModelTests.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		9392A8232C6031490015DD01 /* Repository Details */ = {
+			isa = PBXGroup;
+			children = (
+				9392A82A2C6031A00015DD01 /* ViewModel */,
+				9392A8272C60317D0015DD01 /* View */,
+				9392A8242C6031540015DD01 /* ViewController */,
+			);
+			path = "Repository Details";
+			sourceTree = "<group>";
+		};
+		9392A8242C6031540015DD01 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				9392A8252C6031690015DD01 /* RepositoryDetailViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		9392A8272C60317D0015DD01 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				9392A8282C60318B0015DD01 /* RepositoryDetailView.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		9392A82A2C6031A00015DD01 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				9392A82B2C6032650015DD01 /* RepositoryDetailViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -345,14 +389,18 @@
 			buildActionMask = 2147483647;
 			files = (
 				9392A8222C5F0A480015DD01 /* RepositorySectionHeaderView.swift in Sources */,
+				9392A8262C6031690015DD01 /* RepositoryDetailViewController.swift in Sources */,
 				9392A7FA2C5E07090015DD01 /* GitHubServiceProtocol.swift in Sources */,
 				9392A7FD2C5E07460015DD01 /* NetworkError.swift in Sources */,
 				9392A7F72C5E06B80015DD01 /* GitHubService.swift in Sources */,
+				9392A8292C60318B0015DD01 /* RepositoryDetailView.swift in Sources */,
 				9392A7BF2C5DEBC60015DD01 /* ReposViewController.swift in Sources */,
 				9392A8162C5ED8680015DD01 /* ReposViewModel.swift in Sources */,
 				9392A81D2C5ED9F30015DD01 /* RepositoryCollectionViewCell.swift in Sources */,
+				9392A82C2C6032650015DD01 /* RepositoryDetailViewModel.swift in Sources */,
 				9392A7BB2C5DEBC60015DD01 /* AppDelegate.swift in Sources */,
 				9392A7BD2C5DEBC60015DD01 /* SceneDelegate.swift in Sources */,
+				9392A82E2C6037920015DD01 /* String+Extension.swift in Sources */,
 				9392A7F52C5E06580015DD01 /* Repository.swift in Sources */,
 				9392A8182C5ED9750015DD01 /* ListView.swift in Sources */,
 			);

--- a/GitHubRepository/Screens/Repositories/Model/Repository.swift
+++ b/GitHubRepository/Screens/Repositories/Model/Repository.swift
@@ -4,7 +4,19 @@ struct Repository: Codable, Hashable {
   
   let id: Int
   let name: String
+  let fullName: String?
   let description: String?
+  let stargazersCount: Int
+  let language: String?
+  
+  enum CodingKeys: String, CodingKey {
+    case id
+    case name
+    case fullName = "full_name"
+    case description
+    case stargazersCount = "stargazers_count"
+    case language
+  }
   
   func hash(into hasher: inout Hasher) {
     hasher.combine(id)

--- a/GitHubRepository/Screens/Repositories/ViewController/ReposViewController.swift
+++ b/GitHubRepository/Screens/Repositories/ViewController/ReposViewController.swift
@@ -29,6 +29,7 @@ final class ReposViewController: UIViewController {
     setupViews()
     configureDataSource()
     bindViewModel()
+    contentView.collectionView.delegate = self 
   }
   
   @objc func searchButtonTapped() {
@@ -123,5 +124,14 @@ private extension ReposViewController {
     let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
     alert.addAction(UIAlertAction(title: "OK", style: .default))
     present(alert, animated: true)
+  }
+}
+
+extension ReposViewController: UICollectionViewDelegate {
+  func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    guard let repository = dataSource?.itemIdentifier(for: indexPath) else { return }
+    let detailViewModel = RepositoryDetailViewModel(repository: repository)
+    let detailViewController = RepositoryDetailViewController(viewModel: detailViewModel)
+    navigationController?.pushViewController(detailViewController, animated: true)
   }
 }

--- a/GitHubRepository/Screens/Repository Details/View/RepositoryDetailView.swift
+++ b/GitHubRepository/Screens/Repository Details/View/RepositoryDetailView.swift
@@ -1,0 +1,64 @@
+import UIKit
+
+final class RepositoryDetailView: UIView {
+
+  lazy var descriptionLabel: UILabel = {
+    let label = UILabel()
+    label.numberOfLines = 0
+    label.translatesAutoresizingMaskIntoConstraints = false
+    return label
+  }()
+  
+  lazy var languageLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    return label
+  }()
+  
+  lazy var starsLabel: UILabel = {
+    let label = UILabel()
+    label.translatesAutoresizingMaskIntoConstraints = false
+    return label
+  }()
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupViews()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  private func setupViews() {
+    addSubview(descriptionLabel)
+    addSubview(languageLabel)
+    addSubview(starsLabel)
+    
+    NSLayoutConstraint.activate([
+      descriptionLabel.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+      descriptionLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+      descriptionLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+      
+      languageLabel.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: 8),
+      languageLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+      languageLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+      
+      starsLabel.topAnchor.constraint(equalTo: languageLabel.bottomAnchor, constant: 8),
+      starsLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+      starsLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16)
+    ])
+  }
+  
+  func updateDescriptionLabel(_ description: String) {
+    descriptionLabel.attributedText = description.formattedText(prefix: "Description")
+  }
+  
+  func updateLanguageLabel(_ language: String) {
+    languageLabel.attributedText = language.formattedText(prefix: "Language")
+  }
+  
+  func updateStarsLabel(_ stars: String) {
+    starsLabel.attributedText = stars.formattedText(prefix: "Stars")
+  }
+}

--- a/GitHubRepository/Screens/Repository Details/ViewController/RepositoryDetailViewController.swift
+++ b/GitHubRepository/Screens/Repository Details/ViewController/RepositoryDetailViewController.swift
@@ -1,0 +1,58 @@
+import UIKit
+import Combine
+
+final class RepositoryDetailViewController: UIViewController {
+  
+  private let viewModel: RepositoryDetailViewModel
+  private let detailView = RepositoryDetailView()
+  private var subscriptions = Set<AnyCancellable>()
+  
+  init(viewModel: RepositoryDetailViewModel) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func loadView() {
+    view = detailView
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+    bindViewModel()
+  }
+  
+  private func bindViewModel() {
+    viewModel.$fullName
+      .receive(on: RunLoop.main)
+      .sink { [weak self] fullName in
+        self?.title = fullName
+      }
+      .store(in: &subscriptions)
+    
+    viewModel.$description
+      .receive(on: RunLoop.main)
+      .sink { [weak self] description in
+        self?.detailView.updateDescriptionLabel(description)
+      }
+      .store(in: &subscriptions)
+    
+    viewModel.$language
+      .receive(on: RunLoop.main)
+      .sink { [weak self] language in
+        self?.detailView.updateLanguageLabel(language)
+      }
+      .store(in: &subscriptions)
+    
+    viewModel.$stars
+      .receive(on: RunLoop.main)
+      .sink { [weak self] stars in
+        self?.detailView.updateStarsLabel(stars)
+      }
+      .store(in: &subscriptions)
+  }
+}

--- a/GitHubRepository/Screens/Repository Details/ViewModel/RepositoryDetailViewModel.swift
+++ b/GitHubRepository/Screens/Repository Details/ViewModel/RepositoryDetailViewModel.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Combine
+
+final class RepositoryDetailViewModel: ObservableObject {
+
+  @Published var fullName: String
+  @Published var description: String
+  @Published var language: String
+  @Published var stars: String
+
+  init(repository: Repository) {
+    self.fullName = repository.fullName ?? "Unknown Repository"
+    self.description = repository.description ?? "No description available."
+    self.language = repository.language ?? "N/A"
+    self.stars = "\(String(describing: repository.stargazersCount)) ⭐️"
+  }
+}

--- a/GitHubRepository/Shared/String+Extension.swift
+++ b/GitHubRepository/Shared/String+Extension.swift
@@ -1,0 +1,19 @@
+import UIKit
+
+extension String {
+  
+  /// Creates an attributed string with a bold prefix and a normal value text.
+  ///
+  /// - Parameters:
+  ///   - prefix: The prefix text to be bolded.
+  /// - Returns: An `NSAttributedString` with the prefix in bold and the value in normal font.
+  func formattedText(prefix: String) -> NSAttributedString {
+    let boldAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.boldSystemFont(ofSize: 16)]
+    let normalAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 16)]
+    
+    let attributedString = NSMutableAttributedString(string: "\(prefix): ", attributes: boldAttributes)
+    attributedString.append(NSAttributedString(string: self, attributes: normalAttributes))
+    
+    return attributedString
+  }
+}

--- a/GitHubRepositoryTests/Service/GitHubServiceTests.swift
+++ b/GitHubRepositoryTests/Service/GitHubServiceTests.swift
@@ -32,8 +32,22 @@ class GitHubServiceTests: XCTestCase {
   func testFetchRepositoriesSuccess() {
     let jsonData = """
         [
-            {"id": 1, "name": "Repo1", "description": "Description1"},
-            {"id": 2, "name": "Repo2", "description": "Description2"}
+            {
+                "id": 1,
+                "name": "Repo1",
+                "full_name": "User/Repo1",
+                "description": "Description1",
+                "stargazers_count": 10,
+                "language": "Swift"
+            },
+            {
+                "id": 2,
+                "name": "Repo2",
+                "full_name": "User/Repo2",
+                "description": "Description2",
+                "stargazers_count": 20,
+                "language": "Objective-C"
+            }
         ]
         """.data(using: .utf8)!
     

--- a/GitHubRepositoryTests/ViewModels/ReposViewModelTests.swift
+++ b/GitHubRepositoryTests/ViewModels/ReposViewModelTests.swift
@@ -24,7 +24,7 @@ final class ReposViewModelTests: XCTestCase {
   
   func testFetchRepositoriesSuccess() {
     // Given
-    let repositories = [Repository(id: 1, name: "Repo1", description: "Description1")]
+    let repositories = [Repository(id: 1, name: "Repo1", fullName: "Repo1", description: "Description1", stargazersCount: 12, language: "swift")]
     let expectation = XCTestExpectation(description: "State should be finishedLoading and repositories should be set")
     
     // Observe changes

--- a/GitHubRepositoryTests/ViewModels/RepositoryDetailViewModelTests.swift
+++ b/GitHubRepositoryTests/ViewModels/RepositoryDetailViewModelTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+import Combine
+@testable import GitHubRepository 
+
+final class RepositoryDetailViewModelTests: XCTestCase {
+    
+    var viewModel: RepositoryDetailViewModel!
+    var repository: Repository!
+    var subscriptions: Set<AnyCancellable>!
+    
+    override func setUp() {
+        super.setUp()
+        
+        // Sample repository data
+        repository = Repository(
+            id: 1,
+            name: "TestRepo",
+            fullName: "TestUser/TestRepo",
+            description: "This is a test repository",
+            stargazersCount: 123,
+            language: "Swift"
+        )
+        
+        viewModel = RepositoryDetailViewModel(repository: repository)
+        subscriptions = Set<AnyCancellable>()
+    }
+    
+    override func tearDown() {
+        viewModel = nil
+        repository = nil
+        subscriptions = nil
+        
+        super.tearDown()
+    }
+    
+    func testFullName() {
+        let expectation = XCTestExpectation(description: "Full name should be published")
+        
+        viewModel.$fullName
+            .sink { fullName in
+                XCTAssertEqual(fullName, "TestUser/TestRepo")
+                expectation.fulfill()
+            }
+            .store(in: &subscriptions)
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testDescription() {
+        let expectation = XCTestExpectation(description: "Description should be published")
+        
+        viewModel.$description
+            .sink { description in
+                XCTAssertEqual(description, "This is a test repository")
+                expectation.fulfill()
+            }
+            .store(in: &subscriptions)
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testLanguage() {
+        let expectation = XCTestExpectation(description: "Language should be published")
+        
+        viewModel.$language
+            .sink { language in
+                XCTAssertEqual(language, "Swift")
+                expectation.fulfill()
+            }
+            .store(in: &subscriptions)
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testStars() {
+        let expectation = XCTestExpectation(description: "Stars should be published")
+        
+        viewModel.$stars
+            .sink { stars in
+                XCTAssertEqual(stars, "123 ⭐️")
+                expectation.fulfill()
+            }
+            .store(in: &subscriptions)
+        
+        wait(for: [expectation], timeout: 1.0)
+    }
+    
+    func testDefaultValuesForNilRepositoryProperties() {
+        let repositoryWithNilProperties = Repository(
+            id: 2,
+            name: "TestRepoNil",
+            fullName: nil,
+            description: nil,
+            stargazersCount: 0,
+            language: nil
+        )
+        
+        viewModel = RepositoryDetailViewModel(repository: repositoryWithNilProperties)
+        
+        let fullNameExpectation = XCTestExpectation(description: "Default full name should be published")
+        viewModel.$fullName
+            .sink { fullName in
+                XCTAssertEqual(fullName, "Unknown Repository")
+                fullNameExpectation.fulfill()
+            }
+            .store(in: &subscriptions)
+        
+        let descriptionExpectation = XCTestExpectation(description: "Default description should be published")
+        viewModel.$description
+            .sink { description in
+                XCTAssertEqual(description, "No description available.")
+                descriptionExpectation.fulfill()
+            }
+            .store(in: &subscriptions)
+        
+        let languageExpectation = XCTestExpectation(description: "Default language should be published")
+        viewModel.$language
+            .sink { language in
+                XCTAssertEqual(language, "N/A")
+                languageExpectation.fulfill()
+            }
+            .store(in: &subscriptions)
+        
+        let starsExpectation = XCTestExpectation(description: "Stars should be published")
+        viewModel.$stars
+            .sink { stars in
+                XCTAssertEqual(stars, "0 ⭐️")
+                starsExpectation.fulfill()
+            }
+            .store(in: &subscriptions)
+        
+        wait(for: [fullNameExpectation, descriptionExpectation, languageExpectation, starsExpectation], timeout: 1.0)
+    }
+}


### PR DESCRIPTION
## Summary

This PR includes the implementation of a repository detail screen. When the user taps on a specific repository from the list, they will be navigated to the Repository Detail screen.

## Changes

- Add three new parameters for `Repository` model to show in detail view
- Add `RepositoryDetail` `View`, `ViewController` and `ViewModel` to show data for specific `Repository`
- Add RepositoryDetailViewModelTests
 ![Screenshot 2024-08-05 at 01 10 15](https://github.com/user-attachments/assets/6a8d0b98-1c3c-4cdc-bb76-997780d1f55e)

## Testing

- [x]  Verified that the app builds and runs without issues.
- [x]  Verified that selecting a repository item navigates to the detail view controller.
- [x]  Confirmed that the repository's name is displayed as the title of the detail view controller.
- [x]  Checked that the description, language, and stars are displayed correctly with the appropriate formatting.




## Screenshots

### Repository Detail screen
![Screenshot 2024-08-05 at 01 14 02](https://github.com/user-attachments/assets/d9a5742b-02af-4df8-aec8-936276f46d87)

